### PR TITLE
Add `correlationId` to logs to make sequences of actions easier to track

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import('jest').Config} */
+const config = {
+  preset: "ts-jest",
+  resetMocks: true,
+  testEnvironment: "node",
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -39,10 +39,6 @@
     "type-check": "tsc --noEmit",
     "version": "changeset version && pnpm i --no-frozen-lockfile && git add ."
   },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "node"
-  },
   "lint-staged": {
     "*": [
       "prettier --ignore-unknown --write"

--- a/src/action-factory.ts
+++ b/src/action-factory.ts
@@ -9,7 +9,7 @@ export class ActionFactory<Context, Input, Output> {
     displayName: string,
     handler: ActionHandler<Context, Input, Output>
   ) {
-    this.baseContext = { displayName, logger: console };
+    this.baseContext = { displayName };
     this.handler = handler;
   }
 

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,6 +1,8 @@
-import { mockDeep } from "jest-mock-extended";
 import { Action } from "./action";
+import { Logger } from "./logger";
 import type { ActionBaseContext, ActionHandler } from "./types";
+
+jest.mock("./logger");
 
 interface Context {
   salutation: "Hello" | "Hey" | "Hola";
@@ -22,10 +24,7 @@ function createMockHandler(
 function createMockContext(
   ctx: Context & Pick<ActionBaseContext, "displayName">
 ): Context & ActionBaseContext {
-  return {
-    ...ctx,
-    logger: mockDeep<typeof console>(),
-  };
+  return ctx;
 }
 
 describe("action", () => {
@@ -46,26 +45,43 @@ describe("action", () => {
     });
   });
 
-  describe("#run", () => {
-    let handler: ReturnType<typeof createMockHandler>;
+  describe("#run (happy path)", () => {
     let context: ReturnType<typeof createMockContext>;
+    let handler: ReturnType<typeof createMockHandler>;
     let result: unknown;
 
-    beforeAll(async () => {
-      handler = createMockHandler();
+    beforeEach(async () => {
       context = createMockContext({
         salutation: "Hello",
         displayName: "SayHello",
       });
+      handler = createMockHandler();
+
       const action = new Action(handler, context);
 
       result = await action.run("World");
     });
 
+    it("should initialize the logger with correct context", () => {
+      const expectedContext = {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        correlationId: expect.any(String),
+        displayName: context.displayName,
+      };
+
+      expect(Logger).toHaveBeenCalledWith(expectedContext);
+    });
+
     it("should emit expected log when started", () => {
-      expect(context.logger.info).toHaveBeenNthCalledWith(
+      const loggerInstance = (Logger as jest.Mock<Logger>).mock.instances[0];
+
+      if (!loggerInstance) {
+        throw new Error("Expected loggerInstance to be defined");
+      }
+
+      expect(loggerInstance.info).toHaveBeenNthCalledWith(
         1,
-        '[SayHello] Action Started (input: "World")'
+        'Action Started (input: "World")'
       );
     });
 
@@ -75,41 +91,59 @@ describe("action", () => {
     });
 
     it("should emit expected log when completed", () => {
-      expect(context.logger.info).toHaveBeenLastCalledWith(
-        '[SayHello] Action Completed (data: "Hello, World")'
+      const loggerInstance = (Logger as jest.Mock<Logger>).mock.instances[0];
+
+      if (!loggerInstance) {
+        throw new Error("Expected loggerInstance to be defined");
+      }
+
+      expect(loggerInstance.info).toHaveBeenLastCalledWith(
+        'Action Completed (data: "Hello, World")'
       );
     });
 
     it("should return the expected result", () => {
       expect(result).toStrictEqual({ ok: true, data: "Hello, World" });
     });
+  });
 
-    describe("when the handler throws an error", () => {
-      const expectedError = new Error("Oopsies!");
-      beforeAll(async () => {
-        handler = createMockHandler(() => {
-          throw expectedError;
-        });
-        context = createMockContext({
-          displayName: "SayHello",
-          salutation: "Hello",
-        });
-        const action = new Action(handler, context);
+  describe("#run (when the handler throws an error)", () => {
+    const expectedError = new Error("Oopsies!");
 
-        result = await action.run("World");
+    let context: ReturnType<typeof createMockContext>;
+    let handler: ReturnType<typeof createMockHandler>;
+    let result: unknown;
+
+    beforeEach(async () => {
+      context = createMockContext({
+        displayName: "SayHello",
+        salutation: "Hello",
+      });
+      handler = createMockHandler(() => {
+        throw expectedError;
       });
 
-      it("should emit expected log", () => {
-        expect(context.logger.error).toHaveBeenLastCalledWith(
-          "[SayHello] Action Failed (error: Oopsies!)"
-        );
-      });
+      const action = new Action(handler, context);
 
-      it("should return the expected result", () => {
-        expect(result).toStrictEqual({
-          ok: false,
-          error: expectedError,
-        });
+      result = await action.run("World");
+    });
+
+    it("should emit expected log", () => {
+      const loggerInstance = (Logger as jest.Mock<Logger>).mock.instances[0];
+
+      if (!loggerInstance) {
+        throw new Error("Expected loggerInstance to be defined");
+      }
+
+      expect(loggerInstance.error).toHaveBeenLastCalledWith(
+        "Action Failed (error: Oopsies!)"
+      );
+    });
+
+    it("should return the expected result", () => {
+      expect(result).toStrictEqual({
+        ok: false,
+        error: expectedError,
       });
     });
   });

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,79 @@
+import { Logger } from "./logger";
+
+const displayName = "DisplayName";
+const correlationId = "ABCD1234";
+const message = "The message";
+
+describe("#info", () => {
+  describe("when process.env.NODE_ENV != 'test'", () => {
+    let spy: jest.SpyInstance;
+    beforeEach(() => {
+      process.env.NODE_ENV = "development";
+      spy = jest.spyOn(console, "info").mockImplementationOnce(() => {
+        /* noop */
+      });
+      const logger = new Logger({ displayName, correlationId });
+      logger.info(message);
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = "test";
+    });
+
+    it("should invoke `console.info` with expected arguments", () => {
+      expect(spy).toHaveBeenCalledWith(
+        `[${displayName}:${correlationId}] ${message}`
+      );
+    });
+  });
+
+  describe("when process.env.NODE_ENV = 'test'", () => {
+    let spy: jest.SpyInstance;
+    beforeEach(() => {
+      spy = jest.spyOn(console, "info");
+      const logger = new Logger({ displayName, correlationId });
+      logger.info(message);
+    });
+
+    it("should _not_ invoke `console.info`", () => {
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("#error", () => {
+  describe("when process.env.NODE_ENV != 'test'", () => {
+    let spy: jest.SpyInstance;
+    beforeEach(() => {
+      process.env.NODE_ENV = "development";
+      spy = jest.spyOn(console, "error").mockImplementationOnce(() => {
+        /* noop */
+      });
+      const logger = new Logger({ displayName, correlationId });
+      logger.error(message);
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = "test";
+    });
+
+    it("should invoke `console.error` with expected arguments", () => {
+      expect(spy).toHaveBeenCalledWith(
+        `[${displayName}:${correlationId}] ${message}`
+      );
+    });
+  });
+
+  describe("when process.env.NODE_ENV = 'test'", () => {
+    let spy: jest.SpyInstance;
+    beforeAll(() => {
+      spy = jest.spyOn(console, "error");
+      const logger = new Logger({ displayName, correlationId });
+      logger.error(message);
+    });
+
+    it("should _not_ invoke `console.error` with expected arguments", () => {
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,52 @@
+export interface LoggerContext {
+  displayName: string;
+  correlationId: string;
+}
+
+export class Logger {
+  private readonly ctx: LoggerContext;
+  private readonly quiet: boolean;
+
+  constructor(context: LoggerContext) {
+    this.ctx = context;
+    this.quiet = process.env.NODE_ENV === "test";
+  }
+
+  /**
+   * Log a message to the console using the `info` level. Message will be
+   * prefixed with the `displayName` and `correlationId`
+   *
+   * @example
+   * const logger = new Logger(\{ displayName: "MyClass", correlationId: "ABCD1234" \});
+   * logger.info("My message") // [MyClass:ABCD1234] My message
+   */
+  error(message: string): void {
+    if (this.quiet) return;
+    const formattedMessage = this.formatMessage(message);
+
+    // eslint-disable-next-line no-console
+    console.error(formattedMessage);
+  }
+
+  /**
+   * Log a message to the console using the `info` level. Message will be
+   * prefixed with the `displayName` and `correlationId`
+   *
+   * @example
+   * const logger = new Logger(\{ displayName: "MyClass", correlationId: "ABCD1234" \});
+   * logger.info("My message") // [MyClass:ABCD1234] My message
+   */
+  info(message: string): void {
+    if (this.quiet) return;
+    const formattedMessage = this.formatMessage(message);
+
+    // eslint-disable-next-line no-console
+    console.info(formattedMessage);
+  }
+
+  private formatMessage(message: string): string {
+    const { correlationId, displayName } = this.ctx;
+
+    return `[${displayName}:${correlationId}] ${message}`;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 export interface ActionBaseContext {
   displayName: string;
-  logger: typeof console;
 }
 export interface ActionResultHappy<Output> {
   ok: true;


### PR DESCRIPTION
This update changes the log format from `[ActionDisplayName] Message` to
`[ActionDisplayName:{correlationId}] Message`.

This will allow us to query related actions in the logs by searching for the
`correlationId`.
