### PR TITLE
Expose logger to action handler

### DIFF
--- a/.changeset/proud-beds-confess.md
+++ b/.changeset/proud-beds-confess.md
@@ -1,0 +1,26 @@
+---
+"@tnezdev/actions": minor
+---
+
+Add the logger instance to the context that is passed in to the action handler.
+
+This allows the action handler to send logs with the context established by the action wrapper.
+
+This means that you can do the following in your action handlers:
+
+```ts
+const handler: ActionHandler<Context, Input, Output> = (ctx, input) => {
+  ctx.logger.info("This is a log from inside the action handler");
+
+  // ...do something and return a result
+  return doSomething(input);
+};
+```
+
+And it will yield this log in addition to the normal logs that the wrapper emits:
+
+```
+[{DisplayName}:{CorrelationId}] Action Started (input: {input})]
+[{DisplayName}:{CorrelationId}] This is a log from inside the action handler
+[{DisplayName}:{CorrelationId}] Action Completed (data: {data})]
+```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ export type GetTemperatureContext = {
   scale?: "celsius" | "fahrenheit";
 };
 export type GetTemperatureInput = { zipcode: string };
-export type GetTemperatureOutput = string;
+export type GetTemperatureOutput = { temperature: number };
 
 const handler: ActionHandler<
   GetTemperatureContext,
@@ -37,9 +37,10 @@ const handler: ActionHandler<
   const { client, scale } = ctx;
   const { zipcode } = input;
 
+  ctx.logger.info("You can emit logs from inside the action");
   const { temperature } = await client.getTempearture(zipcode, { scale });
 
-  return temperature;
+  return { temperature };
 };
 
 export const GetTemperatureAction = createAction("GetTemperature", handler);
@@ -84,5 +85,12 @@ When run, this will produce the following logs:
 
 ```txt
 [GetTemparature:{correlation-id}] Action Started (input: {"zipcode":"12345"})
+[GetTemperature:{correlation-id}] You can emit logs from inside the action
 [GetTempearture:{correlation-id}] Action Completed (data: {"temperature":"75˚F"})
+```
+
+And the result returned from the action will be:
+
+```
+{ ok: true, data: { temperature: 72 } }
 ```

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -87,7 +87,11 @@ describe("action", () => {
 
     it("should invoke the handler with expected arguments", () => {
       const input = "World";
-      expect(handler).toHaveBeenCalledWith(context, input);
+      expect(handler).toHaveBeenCalledWith(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        { ...context, logger: expect.any(Logger) },
+        input
+      );
     });
 
     it("should emit expected log when completed", () => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -25,7 +25,7 @@ export class Action<Context, Input, Output> {
 
     try {
       logger.info(`Action Started (input: ${JSON.stringify(input)})`);
-      const data = await this.handler(this.ctx, input);
+      const data = await this.handler({ ...this.ctx, logger }, input);
       logger.info(`Action Completed (data: ${JSON.stringify(data)})`);
       return { ok: true as const, data };
     } catch (possibleError) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Logger } from "./logger";
+
 export interface ActionBaseContext {
   displayName: string;
 }
@@ -13,6 +15,6 @@ export interface ActionResultSad {
 }
 export type ActionResult<Output> = ActionResultHappy<Output> | ActionResultSad;
 export type ActionHandler<Context, Input, Output> = (
-  ctx: Context & ActionBaseContext,
+  ctx: Context & ActionBaseContext & { logger: Logger },
   input: Input
 ) => Promise<Output> | Output;


### PR DESCRIPTION
Add the logger instance to the context that is passed in to the action handler.

This allows the action handler to send logs with the context established by the action wrapper.

This means that you can do the following in your action handlers:

```ts
const handler: ActionHandler<Context, Input, Output> = (ctx, input) => {
  ctx.logger.info('This is a log from inside the action handler');

  // ...do something and return a result
  return doSomething(input);
};
```

And it will yield this log in addition to the normal logs that the wrapper emits:

```
[{DisplayName}:{CorrelationId}] Action Started (input: {input})]
[{DisplayName}:{CorrelationId}] This is a log from inside the action handler
[{DisplayName}:{CorrelationId}] Action Completed (data: {data})]
```
