### PR TITLE
Create examples that illustrate real world usage

### DIFF
--- a/.changeset/pink-foxes-occur.md
+++ b/.changeset/pink-foxes-occur.md
@@ -3,3 +3,17 @@
 ---
 
 Create examples illustrating real world usage
+
+Added `/examples` that contains the following illustrating how **actions**, **clients**, and **entrypoint handlers** all interact.
+
+```
+.
+├── README.md
+├── actions
+│   └── get-pokemon.ts
+├── clients
+│   └── pokemon.ts
+└── entrypoint.ts
+
+2 directories, 4 files
+```

--- a/.changeset/pink-foxes-occur.md
+++ b/.changeset/pink-foxes-occur.md
@@ -1,0 +1,5 @@
+---
+"@tnezdev/actions": patch
+---
+
+Create examples illustrating real world usage

--- a/README.md
+++ b/README.md
@@ -119,3 +119,5 @@ And the result returned from the action will be:
 ```
 { ok: true, data: { temperature: 72 } }
 ```
+
+You can see a more complete example of real-world usage here: [/src/examples/README.md](/src/examples/README.md)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "publint": "0.1.13",
     "ts-jest": "29.1.1",
     "tsup": "7.1.0",
-    "typescript": "5.1.6"
+    "typescript": "5.1.6",
+    "zod": "3.21.4"
   },
   "packageManager": "pnpm@8.6.5",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 devDependencies:
   '@changesets/cli':
     specifier: 2.26.2
@@ -53,6 +49,9 @@ devDependencies:
   typescript:
     specifier: 5.1.6
     version: 5.1.6
+  zod:
+    specifier: 3.21.4
+    version: 3.21.4
 
 packages:
 
@@ -5856,3 +5855,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+    dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -12,14 +12,14 @@ This example contains the following file structure:
 
 ## `entrypoint.ts`
 
-The [entrypoint](/entrypoint.ts) represents something that might be used in an API route or CLI handler.
+The [entrypoint](/src/examples/entrypoint.ts) represents something that might be used in an API route or CLI handler.
 
 In this example it is just an arbitrary function that returns a string when executed, but you can easily imagine this as a route handler in a **NextJS** application.
 
 ## `actions/get-pokemon.ts`
 
-The [actions/get-pokemon.ts](/actions/get-pokemon.ts) contains the actual business logic. This action is **initialized** using the `createAction` method, and all required context is injected upon initialization. This allows us to inject things like mock clients under test as well as clients with appropriate configuration for different deployment environments.
+The [actions/get-pokemon.ts](/src/examples/actions/get-pokemon.ts) contains the actual business logic. This action is **initialized** using the `createAction` method, and all required context is injected upon initialization. This allows us to inject things like mock clients under test as well as clients with appropriate configuration for different deployment environments.
 
 ## `clients/pokemon.ts`
 
-The [clients/pokemon.ts](/clients/pokemon.ts) represents an interface to some service. **Actions** will typically require some kind of clients or other effects to interact with the outside world and produce meaningful side-effects.
+The [clients/pokemon.ts](/src/examples/clients/pokemon.ts) represents an interface to some service. **Actions** will typically require some kind of clients or other effects to interact with the outside world and produce meaningful side-effects.

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -2,7 +2,7 @@ This is an example illustrates how **actions**, **clients**, and **entrypoint ha
 
 This example contains the following file structure:
 
-```tree
+```
 ├── actions
 │   └── get-pokemon.ts
 ├── clients

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -1,0 +1,25 @@
+This is an example illustrates how **actions**, **clients**, and **entrypoint handlers** all interact together.
+
+This example contains the following file structure:
+
+```tree
+├── actions
+│   └── get-pokemon.ts
+├── clients
+│   └── pokemon.ts
+└── entrypoint.ts
+```
+
+## `entrypoint.ts`
+
+The [entrypoint](/entrypoint.ts) represents something that might be used in an API route or CLI handler.
+
+In this example it is just an arbitrary function that returns a string when executed, but you can easily imagine this as a route handler in a **NextJS** application.
+
+## `actions/get-pokemon.ts`
+
+The [actions/get-pokemon.ts](/actions/get-pokemon.ts) contains the actual business logic. This action is **initialized** using the `createAction` method, and all required context is injected upon initialization. This allows us to inject things like mock clients under test as well as clients with appropriate configuration for different deployment environments.
+
+## `clients/pokemon.ts`
+
+The [clients/pokemon.ts](/clients/pokemon.ts) represents an interface to some service. **Actions** will typically require some kind of clients or other effects to interact with the outside world and produce meaningful side-effects.

--- a/src/examples/actions/get-pokemon.ts
+++ b/src/examples/actions/get-pokemon.ts
@@ -1,0 +1,33 @@
+import { createAction } from "../..";
+import type { ActionHandler } from "../..";
+import type { Pokemon, PokemonClient } from "../clients/pokemon";
+
+export interface GetPokemonContext {
+  clients: {
+    pokemon: PokemonClient;
+  };
+}
+
+export interface GetPokemonInput {
+  id: string;
+}
+
+export type GetPokemonOutput = Omit<Pokemon, "attacks">;
+
+const handler: ActionHandler<
+  GetPokemonContext,
+  GetPokemonInput,
+  GetPokemonOutput
+> = async (ctx, input) => {
+  const {
+    clients: { pokemon },
+  } = ctx;
+  const { id } = input;
+
+  ctx.logger.info(`Getting Pokemon with ID: ${id}`);
+  const data = await pokemon.get(id);
+
+  return data;
+};
+
+export const GetPokemonAction = createAction("GetPokemon", handler);

--- a/src/examples/clients/pokemon.ts
+++ b/src/examples/clients/pokemon.ts
@@ -1,0 +1,47 @@
+export interface Attack {
+  name: string;
+  damage: number;
+}
+
+export interface Pokemon {
+  id: string;
+  name: string;
+  img: { alt: string; src: string };
+  health: number;
+  attacks: Attack[];
+}
+
+export class PokemonClient {
+  get(id: string): Promise<Pokemon> {
+    const pokemon = stubPokemon({ id });
+    return new Promise((resolveWith) => {
+      resolveWith(pokemon);
+    });
+  }
+
+  list(): Promise<Pokemon[]> {
+    const pokemon = [
+      stubPokemon({ id: "1" }),
+      stubPokemon({ id: "2" }),
+      stubPokemon({ id: "3" }),
+    ];
+
+    return new Promise((resolveWith) => {
+      resolveWith(pokemon);
+    });
+  }
+}
+
+function stubPokemon(overrides: Partial<Pokemon> = {}): Pokemon {
+  return {
+    id: "1",
+    name: "Bulbasaur",
+    img: { alt: "Bulbasaur", src: "https://..." },
+    health: 100,
+    attacks: [
+      { name: "Tackle", damage: 10 },
+      { name: "Vine Whip", damage: 20 },
+    ],
+    ...overrides,
+  };
+}

--- a/src/examples/entrypoint.ts
+++ b/src/examples/entrypoint.ts
@@ -1,0 +1,25 @@
+import * as z from "zod";
+import { GetPokemonAction } from "./actions/get-pokemon";
+import { PokemonClient } from "./clients/pokemon";
+
+const getPokemon = GetPokemonAction.initialize({
+  clients: {
+    pokemon: new PokemonClient(),
+  },
+});
+
+const InputSchema = z.object({
+  id: z.string(),
+});
+
+export async function someHandler(input: unknown): Promise<string> {
+  const validatedInput = InputSchema.parse(input);
+
+  const result = await getPokemon.run(validatedInput);
+  if (!result.ok) throw result.error;
+  const {
+    data: { id, health, name },
+  } = result;
+
+  return `The pokemon ${name} has an ID of ${id} and starts with ${health} health points`;
+}


### PR DESCRIPTION
Added `/examples` that contains the following illustrating how **actions**, **clients**, and **entrypoint handlers** all interact.

```
.
├── README.md
├── actions
│   └── get-pokemon.ts
├── clients
│   └── pokemon.ts
└── entrypoint.ts

2 directories, 4 files
``` 
