### PR TITLE
Add metadata to output

### DIFF
--- a/.changeset/new-baboons-approve.md
+++ b/.changeset/new-baboons-approve.md
@@ -1,0 +1,39 @@
+---
+"@tnezdev/actions": minor
+---
+
+Add `Metadata` to `ActionOutput`
+
+Previously, the action output would be `{ ok: true, data: Data }` for the happy path and `{ ok: false, error: Error }` for the sad path. We have added a `metadata` property to both paths that is defined thusly:
+
+```ts
+export interface ActionMetadata {
+  correlationId: string;
+  displayName: string;
+  runTime: {
+    start: number;
+    end?: number;
+    duration?: number;
+  };
+}
+```
+
+Which in real-world usage will look something like this:
+
+```
+{
+  ok: true,
+  data: {
+    temperature: 72,
+  },
+  metadata: {
+    correlationId: '<correation-id>',
+    displayName: 'GetTemperature',
+    runTime: {
+      start: 1688674365730,
+      end: 1688674380205,
+      duration: 14475,
+    }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -111,13 +111,27 @@ When run, this will produce the following logs:
 ```txt
 [GetTemparature:{correlation-id}] Action Started (input: {"zipcode":"12345"})
 [GetTemperature:{correlation-id}] You can emit logs from inside the action
-[GetTempearture:{correlation-id}] Action Completed (data: {"temperature":"75˚F"})
+[GetTempearture:{correlation-id}] Action Completed (data: {"temperature":72})
 ```
 
 And the result returned from the action will be:
 
 ```
-{ ok: true, data: { temperature: 72 } }
+{
+  ok: true,
+  data: {
+    temperature: 72,
+  },
+  metadata: {
+    correlationId: '<correation-id>',
+    displayName: 'GetTemperature',
+    runTime: {
+      start: 1688674365730,
+      end: 1688674380205,
+      duration: 14475,
+    }
+  }
+}
 ```
 
 You can see a more complete example of real-world usage here: [/examples/README.md](/examples/README.md)

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -71,7 +71,9 @@ describe("action", () => {
         displayName: context.displayName,
       };
 
-      expect(createLoggerSpy).toHaveBeenCalledWith(expectedContext);
+      expect(createLoggerSpy).toHaveBeenCalledWith(
+        expect.objectContaining(expectedContext)
+      );
     });
 
     it("should emit expected log when started", () => {
@@ -97,7 +99,25 @@ describe("action", () => {
     });
 
     it("should return the expected result", () => {
-      expect(result).toStrictEqual({ ok: true, data: "Hello, World" });
+      expect(result).toHaveProperty("ok", true);
+      expect(result).toHaveProperty("data", "Hello, World");
+      expect(result).toHaveProperty(
+        "metadata.displayName",
+        context.displayName
+      );
+      expect(result).toHaveProperty(
+        "metadata.correlationId",
+        expect.any(String)
+      );
+      expect(result).toHaveProperty(
+        "metadata.runTime.start",
+        expect.any(Number)
+      );
+      expect(result).toHaveProperty("metadata.runTime.end", expect.any(Number));
+      expect(result).toHaveProperty(
+        "metadata.runTime.duration",
+        expect.any(Number)
+      );
     });
   });
 
@@ -129,10 +149,25 @@ describe("action", () => {
     });
 
     it("should return the expected result", () => {
-      expect(result).toStrictEqual({
-        ok: false,
-        error: expectedError,
-      });
+      expect(result).toHaveProperty("ok", false);
+      expect(result).toHaveProperty("error", expectedError);
+      expect(result).toHaveProperty(
+        "metadata.displayName",
+        context.displayName
+      );
+      expect(result).toHaveProperty(
+        "metadata.correlationId",
+        expect.any(String)
+      );
+      expect(result).toHaveProperty(
+        "metadata.runTime.start",
+        expect.any(Number)
+      );
+      expect(result).toHaveProperty("metadata.runTime.end", expect.any(Number));
+      expect(result).toHaveProperty(
+        "metadata.runTime.duration",
+        expect.any(Number)
+      );
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,13 @@ export interface ActionBaseContext {
 interface ActionResultHappy<Output> {
   ok: true;
   data: Output;
-  // metadata: ActionMetadata;
+  metadata: ActionMetadata;
 }
 
 interface ActionResultSad {
   ok: false;
   error: Error;
-  // metadata: ActionMetadata;
+  metadata: ActionMetadata;
 }
 
 export type ActionResult<Output> = ActionResultHappy<Output> | ActionResultSad;
@@ -23,6 +23,16 @@ export type ActionHandler<Context, Input, Output> = (
   ctx: Context & ActionBaseContext & { logger: Logger },
   input: Input
 ) => Promise<Output> | Output;
+
+export interface ActionMetadata {
+  correlationId: string;
+  displayName: string;
+  runTime: {
+    start: number;
+    end?: number;
+    duration?: number;
+  };
+}
 
 /**
  * Return an ActionFactory that can be initialized with context.


### PR DESCRIPTION
Add `Metadata` to `ActionOutput`

Previously, the action output would be `{ ok: true, data: Data }` for the happy path and `{ ok: false, error: Error }` for the sad path. We have added a `metadata` property to both paths that is defined thusly:

```ts
export interface ActionMetadata {
   correlationId: string;
   displayName: string;
   runTime: {
     start: number;
     end?: number;
     duration?: number;
   };
 }
```

Which in real-world usage will look something like this:

```
{
  ok: true,
  data: {
    temperature: 72,
  },
  metadata: {
    correlationId: '<correation-id>',
    displayName: 'GetTemperature',
    runTime: {
      start: 1688674365730,
      end: 1688674380205,
      duration: 14475,
    }
  }
}
```
