### PR TITLE
Fix small bug in `scripts/setup-examples.sh`

### DIFF
--- a/scripts/setup-examples.sh
+++ b/scripts/setup-examples.sh
@@ -20,6 +20,9 @@ for dir in */; do
 	echo "---"
 	# Run pnpm install
 	pnpm install
-	# Change back to the root directory
-	cd "$ROOT_DIR" || exit
+	# Change back to the $ROOT_DIR/examples directory
+	cd "$ROOT_DIR"/examples || exit
 done
+
+# Change back to the root directory
+cd "$ROOT_DIR" || exit


### PR DESCRIPTION
Previously, when multiple examples were included, we were `cd`-ing back to the `$ROOT_DIR` instead of `$ROOT_DIR/examples`. This behavior broke-down when multiple examples existed.

This was not an issue with this repository because we have only included one example to this point, but after implementing a fix in another repository, this fix was applied here as well.
