### PR TITLE
Export Action type for better DX when composing action

### DIFF
--- a/.changeset/smart-spiders-melt.md
+++ b/.changeset/smart-spiders-melt.md
@@ -1,0 +1,40 @@
+---
+"@tnezdev/actions": minor
+---
+
+Export Action type for better DX when composing actions (closes #42)
+
+We now export the `Action` type which allows you to do the following inside custom actions.
+
+```ts
+import type { Action } from "@tnezdev/actions";
+
+/**
+ * You would define your action logic here...
+ */
+export const SomeAction = (createAction<Context, Input, Output> = (
+  ctx,
+  input
+) => {
+  /* ... */
+});
+
+/**
+ * And then finally export the type for this same action
+ */
+export type SomeAction = Action<Context, Input, Output>;
+```
+
+Then you can use these exported action types in the context definition of other actions:
+
+```ts
+import type { SomeAction } from "./some-action";
+
+export interface Context {
+  actions: {
+    someAction: SomeAction;
+  };
+}
+```
+
+To better illustrate how this works, we've included a new [composed-actions example](/examples/composed-actions/README.md).

--- a/.changeset/smart-spiders-melt.md
+++ b/.changeset/smart-spiders-melt.md
@@ -14,7 +14,7 @@ import type { Action } from "@tnezdev/actions";
  */
 export const SomeAction = (createAction<Context, Input, Output> = (
   ctx,
-  input
+  input,
 ) => {
   /* ... */
 });

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,4 +2,5 @@ Inside this directory you will find relevant examples of how this library is use
 
 ## Included Examples
 
-- [Real World](real-world/README.md)
+- [Real World](real-world/README.md): An example of **real world** usage.
+- [Composed Actions](composed-actions/README.md): An example of how you can call **actions** from other **actions**.

--- a/examples/composed-actions/README.md
+++ b/examples/composed-actions/README.md
@@ -1,7 +1,7 @@
-This example illustrates how you would use compose actions. In this case, we want to express the business use case of: **SignUpNewUser**. When this happens, we might want to do a few things:
+This example illustrates how you would use compose actions. In this case, we want to express the business use case of: **users/sign-up**. When this happens, we might want to do a few things:
 
 1. Persist a new user to the data store
 2. Verify the user's email by sending an email with a verification link
 3. Send a welcome email
 
-See the (actions/sign-up-new-user.ts)[actions/sign-up-new-user.ts] to see how these actions are composed together.
+See the [src/actions/users/sign-up.ts](src/actions/users/sign-up.ts) to see how these actions are composed together.

--- a/examples/composed-actions/README.md
+++ b/examples/composed-actions/README.md
@@ -1,0 +1,7 @@
+This example illustrates how you would use compose actions. In this case, we want to express the business use case of: **SignUpNewUser**. When this happens, we might want to do a few things:
+
+1. Persist a new user to the data store
+2. Verify the user's email by sending an email with a verification link
+3. Send a welcome email
+
+See the (actions/sign-up-new-user.ts)[actions/sign-up-new-user.ts] to see how these actions are composed together.

--- a/examples/composed-actions/package.json
+++ b/examples/composed-actions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "composed-actions",
+  "version": "1.0.0",
+  "dependencies": {
+    "@tnezdev/actions": "link:../..",
+    "zod": "^3.21.4"
+  }
+}

--- a/examples/composed-actions/pnpm-lock.yaml
+++ b/examples/composed-actions/pnpm-lock.yaml
@@ -1,0 +1,15 @@
+lockfileVersion: '6.0'
+
+dependencies:
+  '@tnezdev/actions':
+    specifier: link:../..
+    version: link:../..
+  zod:
+    specifier: ^3.21.4
+    version: 3.21.4
+
+packages:
+
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+    dev: false

--- a/examples/composed-actions/src/actions/users/create-email-verification-token.ts
+++ b/examples/composed-actions/src/actions/users/create-email-verification-token.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { createAction } from "@tnezdev/actions";
 import type { Action, ActionHandler } from "@tnezdev/actions";
-import type { Cache } from "@/effects/cache";
-import type { User } from "@/schemas/user";
+import type { Cache } from "../../effects/cache";
+import type { User } from "../../schemas/user";
 
 export interface Context {
   effects: {

--- a/examples/composed-actions/src/actions/users/create-email-verification-token.ts
+++ b/examples/composed-actions/src/actions/users/create-email-verification-token.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from "node:crypto";
+import { createAction } from "@tnezdev/actions";
+import type { Action, ActionHandler } from "@tnezdev/actions";
+import type { Cache } from "@/effects/cache";
+import type { User } from "@/schemas/user";
+
+export interface Context {
+  effects: {
+    cache: Cache;
+  };
+}
+
+export interface Input {
+  user: User;
+}
+
+export interface Output {
+  token: string;
+}
+
+export const handler: ActionHandler<Context, Input, Output> = async (
+  ctx,
+  input,
+) => {
+  const {
+    effects: { cache },
+  } = ctx;
+  const { user } = input;
+
+  const token = randomUUID();
+  const data = {
+    email: user.email,
+    token,
+  };
+  const options = { ttl: 60 * 60 * 24 };
+  await cache.set(user.id, data, options);
+
+  return { token };
+};
+
+export const CreateEmailVerificationTokenAction = createAction(
+  "CreateEmailVerificationTokenAction",
+  handler,
+);
+
+export type CreateEmailVerificationTokenAction = Action<Context, Input, Output>;

--- a/examples/composed-actions/src/actions/users/request-email-verification.ts
+++ b/examples/composed-actions/src/actions/users/request-email-verification.ts
@@ -1,0 +1,54 @@
+import { createAction } from "@tnezdev/actions";
+import type { Action, ActionHandler } from "@tnezdev/actions";
+import type { CreateEmailVerificationTokenAction } from "@/actions/users/create-email-verification-token";
+import type { Email } from "@/effects/email";
+import type { User } from "@/schemas/user";
+
+export interface Context {
+  actions: {
+    createEmailVerificationToken: CreateEmailVerificationTokenAction;
+  };
+  config: {
+    baseUrl: string;
+  };
+  effects: {
+    email: Email;
+  };
+}
+
+export interface Input {
+  user: User;
+}
+
+export type Output = undefined;
+
+export const handler: ActionHandler<Context, Input, Output> = async (
+  ctx,
+  input,
+) => {
+  const {
+    actions: { createEmailVerificationToken },
+    config: { baseUrl },
+    effects: { email },
+  } = ctx;
+  const { user } = input;
+
+  const createEmailVerificationTokenResult =
+    await createEmailVerificationToken.run({
+      user,
+    });
+  if (!createEmailVerificationTokenResult.ok) {
+    throw createEmailVerificationTokenResult.error;
+  }
+
+  const subject = `Please verify your email ${user.displayName}!`;
+  const body = `Welcome ${user.displayName}! Please verify your email by clicking this link: ${baseUrl}/verify-email?token=${createEmailVerificationTokenResult.data.token}`;
+  await email.send(user.email, subject, body);
+};
+
+export const RequestEmailVerificationAction = createAction(
+  "RequestEmailVerificationAction",
+  handler,
+);
+
+export type RequestEmailVerificationAction = Action<Context, Input, Output>;

--- a/examples/composed-actions/src/actions/users/request-email-verification.ts
+++ b/examples/composed-actions/src/actions/users/request-email-verification.ts
@@ -1,8 +1,8 @@
 import { createAction } from "@tnezdev/actions";
 import type { Action, ActionHandler } from "@tnezdev/actions";
-import type { CreateEmailVerificationTokenAction } from "@/actions/users/create-email-verification-token";
-import type { Email } from "@/effects/email";
-import type { User } from "@/schemas/user";
+import type { Email } from "../../effects/email";
+import type { User } from "../../schemas/user";
+import type { CreateEmailVerificationTokenAction } from "./create-email-verification-token";
 
 export interface Context {
   actions: {
@@ -20,9 +20,7 @@ export interface Input {
   user: User;
 }
 
-export type Output = undefined;
-
-export const handler: ActionHandler<Context, Input, Output> = async (
+export const handler: ActionHandler<Context, Input, void> = async (
   ctx,
   input,
 ) => {
@@ -51,4 +49,4 @@ export const RequestEmailVerificationAction = createAction(
   handler,
 );
 
-export type RequestEmailVerificationAction = Action<Context, Input, Output>;
+export type RequestEmailVerificationAction = Action<Context, Input, void>;

--- a/examples/composed-actions/src/actions/users/sign-up.ts
+++ b/examples/composed-actions/src/actions/users/sign-up.ts
@@ -1,5 +1,5 @@
 import { createAction } from "@tnezdev/actions";
-import type { ActionHandler } from "@tnezdev/actions";
+import type { Action, ActionHandler } from "@tnezdev/actions";
 import type { Data } from "../../effects/data";
 import type { User } from "../../schemas/user";
 import type { RequestEmailVerificationAction } from "./request-email-verification";
@@ -16,9 +16,13 @@ export interface Input {
   user: User;
 }
 
+export interface Output {
+  message: string;
+}
+
 export const DISPLAY_NAME = "ActionName";
 
-const handler: ActionHandler<Context, Input, void> = async (ctx, input) => {
+const handler: ActionHandler<Context, Input, Output> = async (ctx, input) => {
   const {
     actions: { requestEmailVerificationAction },
     effects: { data },
@@ -27,9 +31,15 @@ const handler: ActionHandler<Context, Input, void> = async (ctx, input) => {
 
   await data.insert("Users", user);
   await requestEmailVerificationAction.run({ user });
+
+  return {
+    message: `Successfully signed up new user: ${user.id} (${user.displayName})`,
+  };
 };
 
-export const ActionName = createAction<Context, Input, void>(
+export const UserSignUpAction = createAction<Context, Input, Output>(
   DISPLAY_NAME,
   handler,
 );
+
+export type UserSignUpAction = Action<Context, Input, Output>;

--- a/examples/composed-actions/src/actions/users/sign-up.ts
+++ b/examples/composed-actions/src/actions/users/sign-up.ts
@@ -1,8 +1,8 @@
 import { createAction } from "@tnezdev/actions";
 import type { ActionHandler } from "@tnezdev/actions";
-import type { RequestEmailVerificationAction } from "@/actions/users/request-email-verification";
-import type { Data } from "@/effects/data";
-import type { User } from "@/schemas/user";
+import type { Data } from "../../effects/data";
+import type { User } from "../../schemas/user";
+import type { RequestEmailVerificationAction } from "./request-email-verification";
 
 export interface Context {
   actions: {
@@ -16,11 +16,9 @@ export interface Input {
   user: User;
 }
 
-export type Output = undefined;
-
 export const DISPLAY_NAME = "ActionName";
 
-const handler: ActionHandler<Context, Input, Output> = async (ctx, input) => {
+const handler: ActionHandler<Context, Input, void> = async (ctx, input) => {
   const {
     actions: { requestEmailVerificationAction },
     effects: { data },
@@ -31,7 +29,7 @@ const handler: ActionHandler<Context, Input, Output> = async (ctx, input) => {
   await requestEmailVerificationAction.run({ user });
 };
 
-export const ActionName = createAction<Context, Input, Output>(
+export const ActionName = createAction<Context, Input, void>(
   DISPLAY_NAME,
   handler,
 );

--- a/examples/composed-actions/src/actions/users/sign-up.ts
+++ b/examples/composed-actions/src/actions/users/sign-up.ts
@@ -1,0 +1,37 @@
+import { createAction } from "@tnezdev/actions";
+import type { ActionHandler } from "@tnezdev/actions";
+import type { RequestEmailVerificationAction } from "@/actions/users/request-email-verification";
+import type { Data } from "@/effects/data";
+import type { User } from "@/schemas/user";
+
+export interface Context {
+  actions: {
+    requestEmailVerificationAction: RequestEmailVerificationAction;
+  };
+  effects: {
+    data: Data;
+  };
+}
+export interface Input {
+  user: User;
+}
+
+export type Output = undefined;
+
+export const DISPLAY_NAME = "ActionName";
+
+const handler: ActionHandler<Context, Input, Output> = async (ctx, input) => {
+  const {
+    actions: { requestEmailVerificationAction },
+    effects: { data },
+  } = ctx;
+  const { user } = input;
+
+  await data.insert("Users", user);
+  await requestEmailVerificationAction.run({ user });
+};
+
+export const ActionName = createAction<Context, Input, Output>(
+  DISPLAY_NAME,
+  handler,
+);

--- a/examples/composed-actions/src/effects/cache.ts
+++ b/examples/composed-actions/src/effects/cache.ts
@@ -1,0 +1,8 @@
+export interface Cache {
+  get: <T>(key: string) => Promise<T>;
+  set: <T>(
+    key: string,
+    data: T,
+    options?: Partial<{ ttl: number }>,
+  ) => Promise<void>;
+}

--- a/examples/composed-actions/src/effects/data.ts
+++ b/examples/composed-actions/src/effects/data.ts
@@ -1,0 +1,4 @@
+export interface Data {
+  insert: <T>(table: string, document: T) => Promise<T>;
+  update: <T>(table: string, id: string, document: Partial<T>) => Promise<T>;
+}

--- a/examples/composed-actions/src/effects/email.ts
+++ b/examples/composed-actions/src/effects/email.ts
@@ -1,0 +1,3 @@
+export interface Email {
+  send: (to: string, subject: string, body: string) => Promise<void>;
+}

--- a/examples/composed-actions/src/schemas/user.ts
+++ b/examples/composed-actions/src/schemas/user.ts
@@ -1,0 +1,10 @@
+import * as z from "zod";
+
+export const User = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  email: z.string().email(),
+  emailVerified: z.boolean().default(false),
+});
+
+export type User = z.infer<typeof User>;

--- a/examples/composed-actions/tsconfig.json
+++ b/examples/composed-actions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Default",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "strict": true,
+    "baseUrl": "src/",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "exclude": ["node_modules"],
+  "include": ["**/*.ts"]
+}

--- a/examples/composed-actions/tsconfig.json
+++ b/examples/composed-actions/tsconfig.json
@@ -2,13 +2,8 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
-    "skipLibCheck": true,
-    "strict": true,
-    "baseUrl": "src/",
-    "paths": {
-      "@/*": ["*"]
-    }
+    "strict": true
   },
   "exclude": ["node_modules"],
-  "include": ["**/*.ts"]
+  "include": ["src"]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export type ActionResult<Output> = ActionResultHappy<Output> | ActionResultSad;
 
 export type ActionHandler<Context, Input, Output> = (
   ctx: Context & ActionBaseContext & { logger: Logger },
-  input: Input
+  input: Input,
 ) => Promise<Output> | Output;
 
 export interface ActionMetadata {
@@ -41,7 +41,7 @@ export interface ActionMetadata {
  */
 export function createAction<Context, Input, Output>(
   displayName: string,
-  handler: ActionHandler<Context, Input, Output>
+  handler: ActionHandler<Context, Input, Output>,
 ): ActionFactory<Context, Input, Output> {
   return new ActionFactory(displayName, handler);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { ActionFactory } from "./action-factory";
 import type { Logger } from "./logger";
 
+export type { Action } from "./action";
+
 export interface ActionBaseContext {
   displayName: string;
 }
@@ -21,7 +23,7 @@ export type ActionResult<Output> = ActionResultHappy<Output> | ActionResultSad;
 
 export type ActionHandler<Context, Input, Output> = (
   ctx: Context & ActionBaseContext & { logger: Logger },
-  input: Input,
+  input: Input
 ) => Promise<Output> | Output;
 
 export interface ActionMetadata {
@@ -39,7 +41,7 @@ export interface ActionMetadata {
  */
 export function createAction<Context, Input, Output>(
   displayName: string,
-  handler: ActionHandler<Context, Input, Output>,
+  handler: ActionHandler<Context, Input, Output>
 ): ActionFactory<Context, Input, Output> {
   return new ActionFactory(displayName, handler);
 }


### PR DESCRIPTION
Export Action type for better DX when composing actions (closes #42)

We now export the `Action` type which allows you to do the following inside custom actions.

```ts
import type { Action } from "@tnezdev/actions";

/**
 * You would define your action logic here...
 */
export const SomeAction = (createAction<Context, Input, Output> = (
  ctx,
  input,
) => {
  /* ... */
});

/**
 * And then finally export the type for this same action
 */
export type SomeAction = Action<Context, Input, Output>;
```

Then you can use these exported action types in the context definition of other actions:

```ts
import type { SomeAction } from "./some-action";

export interface Context {
  actions: {
    someAction: SomeAction;
  };
}
```

To better illustrate how this works, we've included a new [composed-actions example](/examples/composed-actions/README.md).
